### PR TITLE
有关安卓6.0和某些业务逻辑的一些修改

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,8 +5,7 @@
       <GradleProjectSettings>
         <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="D:\Program Files\Android\Android Studio\gradle\gradle-2.4" />
-        <option name="gradleJvm" value="1.7" />
+        <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.10" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/ZjsnViewer.iml
+++ b/ZjsnViewer.iml
@@ -13,7 +13,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/app/app.iml
+++ b/app/app.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -80,9 +72,16 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -99,6 +99,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -99,7 +99,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -80,8 +72,17 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -47,6 +47,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
@@ -54,6 +55,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -61,13 +63,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -75,34 +71,39 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.1.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.4.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.4.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.4.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jaredrummler/android-processes/1.0.8/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="animated-vector-drawable-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="android-processes-1.0.8" level="project" />
+    <orderEntry type="library" exported="" name="support-vector-drawable-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="android-android-23" level="project" />
   </component>
 </module>

--- a/app/app.iml
+++ b/app/app.iml
@@ -82,19 +82,33 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.jaredrummler/android-processes/1.0.8/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 27
-        versionName "2.7.1rc1"
+        versionName "2.7.1rc2"
     }
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 26
-        versionName "2.6 - G"
+        versionName "2.7rc1"
     }
     lintOptions {
         abortOnError false
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:support-v4:23.4.0'
+    compile 'com.jaredrummler:android-processes:1.0.8'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "me.crafter.android.zjsnviewer"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 26
-        versionName "2.7rc1"
+        versionCode 27
+        versionName "2.7.1rc1"
     }
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "21.1.2"
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         applicationId "me.crafter.android.zjsnviewer"
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.4.0'
     compile 'com.android.support:support-v4:23.4.0'
     compile 'com.jaredrummler:android-processes:1.0.8'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="me.crafter.android.zjsnviewer">
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
-        tools:ignore="ProtectedPermissions"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
@@ -267,7 +267,7 @@ public class DockInfo {
     public static boolean requestUpdate(Context context){
         boolean ret = true;
         Log.i("DockInfo", "Current Interval is " + updateInterval + " (" + (currentUnix() - lastUpdate) + ")");
-        switch (ZjsnState.getZjsnState(context, TimerService.NOTIFY_INTERVAL)) {
+        switch (ZjsnState.getZjsnState()) {
             case 0:
                 zjsn_running_state = true;
                 //Zjsn in running(both foreground and background)
@@ -288,15 +288,10 @@ public class DockInfo {
             }
         }
 
-        ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-        List<ActivityManager.RunningAppProcessInfo> procInfos = activityManager.getRunningAppProcesses();
-        for (int i = 0; i < procInfos.size(); i++){
-            String processName = procInfos.get(i).processName;
-            if (processName.startsWith("com.muka.shipwar")||processName.startsWith("com.huanmeng.zhanjian2")){
-                DockInfo.updateInterval = 15;
-                Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
-                break;
-            }
+
+        if (zjsn_running_state){
+            DockInfo.updateInterval = 15;
+            Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
         }
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
@@ -268,16 +268,13 @@ public class DockInfo {
         boolean ret = true;
         Log.i("DockInfo", "Current Interval is " + updateInterval + " (" + (currentUnix() - lastUpdate) + ")");
         switch (ZjsnState.getZjsnState(context, TimerService.NOTIFY_INTERVAL)) {
-            case -1:
-                //Nothing happen.
-                break;
             case 0:
                 zjsn_running_state = true;
-                //Zjsn in foreground
+                //Zjsn in running(both foreground and background)
                 break;
             case 1:
                 zjsn_running_state = false;
-                //Zjsn in background
+                //Zjsn in not running
                 break;
         }
         if(!zjsn_running_state) {
@@ -294,7 +291,8 @@ public class DockInfo {
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         List<ActivityManager.RunningAppProcessInfo> procInfos = activityManager.getRunningAppProcesses();
         for (int i = 0; i < procInfos.size(); i++){
-            if (procInfos.get(i).processName.startsWith("com.muka.shipwar")){
+            String processName = procInfos.get(i).processName;
+            if (processName.startsWith("com.muka.shipwar")||processName.startsWith("com.huanmeng.zhanjian2")){
                 DockInfo.updateInterval = 15;
                 Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
                 break;

--- a/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
@@ -279,8 +279,10 @@ public class DockInfo {
                 //Zjsn in not running
                 break;
         }
-        if(!zjsn_running_state) {
-            if (currentUnix() - lastUpdate > updateInterval || zjsn_formal_state != zjsn_running_state) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+//        如果战舰少女没有运行或者自动运行被关闭则允许更新
+        if(!zjsn_running_state||!prefs.getBoolean("auto_run", true)) {
+            if (currentUnix() - lastUpdate > updateInterval || zjsn_formal_state != zjsn_running_state||!prefs.getBoolean("auto_run", true)) {
                 //lastUpdate is put before updateDockInfo
                 //to prevent multi request caused by delay
                 lastUpdate = currentUnix();
@@ -291,12 +293,11 @@ public class DockInfo {
         }
 
 
-        if (zjsn_running_state){
+        if (zjsn_running_state&&prefs.getBoolean("auto_run", true)){
             DockInfo.updateInterval = 15;
             Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
         }
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         Boolean on = prefs.getBoolean("on", false);
         if (!on){
             DockInfo.updateInterval = 15;

--- a/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class DockInfo {
 
     static boolean zjsn_running_state = false;
+    static boolean zjsn_formal_state = false;
     public static int lastUpdate = -1;
 
     public static int[] dockTravelTime = {0, 0, 0, 0};
@@ -267,6 +268,7 @@ public class DockInfo {
     public static boolean requestUpdate(Context context){
         boolean ret = true;
         Log.i("DockInfo", "Current Interval is " + updateInterval + " (" + (currentUnix() - lastUpdate) + ")");
+        zjsn_formal_state = zjsn_running_state;
         switch (ZjsnState.getZjsnState()) {
             case 0:
                 zjsn_running_state = true;
@@ -278,7 +280,7 @@ public class DockInfo {
                 break;
         }
         if(!zjsn_running_state) {
-            if (currentUnix() - lastUpdate > updateInterval) {
+            if (currentUnix() - lastUpdate > updateInterval || zjsn_formal_state != zjsn_running_state) {
                 //lastUpdate is put before updateDockInfo
                 //to prevent multi request caused by delay
                 lastUpdate = currentUnix();

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
@@ -92,7 +92,7 @@ public class NetworkManager {
         }
 
 
-        if (ZjsnState.getZjsnState() == 0){
+        if (ZjsnState.getZjsnState() == 0 && prefs.getBoolean("auto_run", true)){
             DockInfo.updateInterval = 15;
             Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
             return;

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
@@ -92,7 +92,7 @@ public class NetworkManager {
         }
 
 
-        if (ZjsnState.getZjsnState() == 1){
+        if (ZjsnState.getZjsnState() == 0){
             DockInfo.updateInterval = 15;
             Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
             return;

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
@@ -91,16 +91,13 @@ public class NetworkManager {
             return;
         }
 
-        ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-        List<ActivityManager.RunningAppProcessInfo> procInfos = activityManager.getRunningAppProcesses();
-        for (int i = 0; i < procInfos.size(); i++){
-            String processName = procInfos.get(i).processName;
-            if (processName.startsWith("com.muka.shipwar") || processName.startsWith("com.huanmeng.zhanjian2")){
-                DockInfo.updateInterval = 15;
-                Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
-                return;
-            }
+
+        if (ZjsnState.getZjsnState() == 1){
+            DockInfo.updateInterval = 15;
+            Storage.str_tiduName = Storage.str_gameRunning[Storage.language];
+            return;
         }
+
         String error = "";
 
         try {

--- a/app/src/main/java/me/crafter/android/zjsnviewer/Storage.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/Storage.java
@@ -70,8 +70,8 @@ public class Storage {
 
     public static float getTextSizeMajor(Context context){
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String size = prefs.getString("textsize_major", "48");
-        float ret = 48;
+        String size = prefs.getString("textsize_major", "24");
+        float ret = 24;
         try {
             ret = Float.parseFloat(size);
         } catch (Exception ex) {}
@@ -81,8 +81,8 @@ public class Storage {
 
     public static float getTextSizeMinor(Context context){
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String size = prefs.getString("textsize_minor", "48");
-        float ret = 48;
+        String size = prefs.getString("textsize_minor", "24");
+        float ret = 24;
         try {
             ret = Float.parseFloat(size);
         } catch (Exception ex) {}

--- a/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
@@ -96,7 +96,9 @@ public class TimerService extends Service {
             Context context = instance;
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             Storage.language = Integer.parseInt(prefs.getString("language", "0"));
-            DockInfo.requestUpdate(context);
+            if (prefs.getBoolean("auto_run", true)) {
+                DockInfo.requestUpdate(context);
+            }
             //notification checker
             if (DockInfo.shouldNotify(context)){
                 NotificationSender.notify(context, Storage.str_reportTitle[Storage.language], DockInfo.getStatusReportAllFull());

--- a/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
@@ -34,6 +34,12 @@ public class TimerService extends Service {
     private Timer mTimer = null;
 
     @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // If we get killed, after returning from here, restart
+        return START_STICKY;
+    }
+
+    @Override
     public IBinder onBind(Intent intent) {
         return null;
     }

--- a/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
@@ -6,9 +6,10 @@ import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.widget.RemoteViews;
-
+import android.util.Log;
 
 public class Widget_Main extends AppWidgetProvider {
 
@@ -47,16 +48,29 @@ public class Widget_Main extends AppWidgetProvider {
         //Toast.makeText(context, "啦啦啦", Toast.LENGTH_SHORT).show();
         updateWidget(context);
     }
-
+    private class UpdateTask extends AsyncTask<Void,Void,Void> {
+        private Context context=null;
+        public UpdateTask(Context main_context){
+            context = main_context;
+        }
+        @Override
+        protected Void doInBackground(Void... params) {
+            DockInfo.updateInterval = 1;
+            DockInfo.requestUpdate(context);
+            Widget_Main.updateWidget(context);
+            return null;
+        }
+    }
     @Override
     public void onReceive(Context context, Intent intent) {
         // TODO Auto-generated method stub
         super.onReceive(context, intent);
 
         if (SYNC_CLICKED.equals(intent.getAction())) {
-            DockInfo.requestUpdate(context);
-            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+            Log.i("widget","clicked");
 
+            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+            new UpdateTask(context).execute();
             RemoteViews remoteViews;
             ComponentName watchWidget;
 
@@ -64,7 +78,7 @@ public class Widget_Main extends AppWidgetProvider {
             watchWidget = new ComponentName(context, Widget_Main.class);
 
 //            remoteViews.setTextViewText(R.id.imageButton, "TESTING");
-            Widget_Main.updateWidget(context);
+
             appWidgetManager.updateAppWidget(watchWidget, remoteViews);
 
         }

--- a/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
@@ -12,6 +12,7 @@ import android.widget.RemoteViews;
 
 public class Widget_Main extends AppWidgetProvider {
 
+    private static final String SYNC_CLICKED    = "automaticWidgetSyncButtonClick";
     @Override
     public void onEnabled(Context context) {
         context.startService(new Intent(context, TimerService.class));
@@ -29,6 +30,14 @@ public class Widget_Main extends AppWidgetProvider {
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds){
         context.startService(new Intent(context, TimerService.class));
         super.onUpdate(context, appWidgetManager, appWidgetIds);
+        RemoteViews remoteViews;
+        ComponentName watchWidget;
+
+        remoteViews = new RemoteViews(context.getPackageName(), R.layout.widget__main);
+        watchWidget = new ComponentName(context, Widget_Main.class);
+
+        remoteViews.setOnClickPendingIntent(R.id.imageButton, getPendingSelfIntent(context, SYNC_CLICKED));
+        appWidgetManager.updateAppWidget(watchWidget, remoteViews);
         updateWidget(context);
     }
 
@@ -39,6 +48,32 @@ public class Widget_Main extends AppWidgetProvider {
         updateWidget(context);
     }
 
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        // TODO Auto-generated method stub
+        super.onReceive(context, intent);
+
+        if (SYNC_CLICKED.equals(intent.getAction())) {
+
+            AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
+
+            RemoteViews remoteViews;
+            ComponentName watchWidget;
+
+            remoteViews = new RemoteViews(context.getPackageName(), R.layout.widget__main);
+            watchWidget = new ComponentName(context, Widget_Main.class);
+
+//            remoteViews.setTextViewText(R.id.imageButton, "TESTING");
+
+            appWidgetManager.updateAppWidget(watchWidget, remoteViews);
+
+        }
+    }
+    protected PendingIntent getPendingSelfIntent(Context context, String action) {
+        Intent intent = new Intent(context, getClass());
+        intent.setAction(action);
+        return PendingIntent.getBroadcast(context, 0, intent, 0);
+    }
 
     public static void updateWidget(Context context){
         updateWidget(context, AppWidgetManager.getInstance(context));
@@ -46,10 +81,11 @@ public class Widget_Main extends AppWidgetProvider {
 
     public static void updateWidget(Context context, AppWidgetManager appWidgetManager){
         //Log.i("Widget_Main", "updateWidget()");
-        PendingIntent pending = Storage.getStartPendingIntent(context);
+//        PendingIntent pending = Storage.getStartPendingIntent(context);
+//        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget__main);
-
-        views.setOnClickPendingIntent(R.id.imageButton, pending);
+//
+//        views.setOnClickPendingIntent(R.id.imageButton, pendingIntent);
 
         //SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         //views.setTextViewText(R.id.textView, "Last Update: " + sdf.format(new Date()));

--- a/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
@@ -54,7 +54,7 @@ public class Widget_Main extends AppWidgetProvider {
         super.onReceive(context, intent);
 
         if (SYNC_CLICKED.equals(intent.getAction())) {
-
+            DockInfo.requestUpdate(context);
             AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(context);
 
             RemoteViews remoteViews;
@@ -64,7 +64,7 @@ public class Widget_Main extends AppWidgetProvider {
             watchWidget = new ComponentName(context, Widget_Main.class);
 
 //            remoteViews.setTextViewText(R.id.imageButton, "TESTING");
-
+            Widget_Main.updateWidget(context);
             appWidgetManager.updateAppWidget(watchWidget, remoteViews);
 
         }

--- a/app/src/main/java/me/crafter/android/zjsnviewer/ZjsnState.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/ZjsnState.java
@@ -17,8 +17,8 @@ import java.util.List;
  * Edit by PaleNeutron on 2016/5/25.
  */
 public class ZjsnState {
-
-    public static int getZjsnState(Context context, long updateInterval) {
+//if running return 0
+    public static int getZjsnState() {
         List<AndroidAppProcess> processes = AndroidProcesses.getRunningAppProcesses();
         for (int i = 0; i < processes.size(); i++) {
             String processName = processes.get(i).name;

--- a/app/src/main/java/me/crafter/android/zjsnviewer/ZjsnState.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/ZjsnState.java
@@ -8,54 +8,25 @@ import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
+import com.jaredrummler.android.processes.AndroidProcesses;
+import com.jaredrummler.android.processes.models.AndroidAppProcess;
+
+import java.util.List;
 /**
  * Created by JohnnySun on 2015/11/19.
+ * Edit by PaleNeutron on 2016/5/25.
  */
 public class ZjsnState {
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public static boolean isUsageStatsAllowed(Context context) {
-        AppOpsManager appOps = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
-        int uid = android.os.Process.myUid();
-        int mode = appOps.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, uid, context.getPackageName());
-        return  mode == AppOpsManager.MODE_ALLOWED;
-    }
-
     public static int getZjsnState(Context context, long updateInterval) {
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (!isUsageStatsAllowed(context)) {
-                Log.i("getZjsnState", "Permission Not Allowed!!");
-                return -1;
+        List<AndroidAppProcess> processes = AndroidProcesses.getRunningAppProcesses();
+        for (int i = 0; i < processes.size(); i++) {
+            String processName = processes.get(i).name;
+            if (processName.startsWith("com.huanmeng.zhanjian2")||processName.startsWith("com.muka.shipwar")){
+                Log.i("Zjsn_ACTIVE", "Zjsn is in processes");
+                return 0;
             }
-        } else {
-            return -1;
         }
-
-        long time = System.currentTimeMillis();
-        UsageStatsManager usm = (UsageStatsManager) context.getSystemService("usagestats");
-        //long interval = updateInterval * 1000;
-        UsageEvents events = usm.queryEvents(time - updateInterval, time);
-        while (events.hasNextEvent()) {
-            UsageEvents.Event event = new UsageEvents.Event();
-            if(events.getNextEvent(event)) {
-                if(event.getEventType() == UsageEvents.Event.MOVE_TO_FOREGROUND) {
-                    Log.i("packagename", event.getPackageName());
-                    if(event.getPackageName().startsWith("com.muka.shipwar") || event.getPackageName().startsWith("com.huanmeng.zhanjian2")) {
-                        Log.i("getZjsnState", "Zjsn Move to Foreground");
-                        return 0;
-                    }
-                }else  if(event.getEventType() == UsageEvents.Event.MOVE_TO_BACKGROUND) {
-                        Log.i("packagename", event.getPackageName());
-                        if (event.getPackageName().startsWith("com.muka.shipwar") || event.getPackageName().startsWith("com.huanmeng.zhanjian2")) {
-                            Log.i("getZjsnState", "Zjsn Move to Background");
-                            return 1;
-                        }
-                    }
-
-            }
-
-        }
-        Log.i("getZjsnState", "Zjsn not cache");
-        return -1;
+        return 1;
     }
 }

--- a/app/src/main/java/me/crafter/android/zjsnviewer/ZjsnViewer.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/ZjsnViewer.java
@@ -1,6 +1,7 @@
 package me.crafter.android.zjsnviewer;
 
 import android.content.Context;
+import android.content.Intent;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
@@ -24,6 +25,12 @@ public class ZjsnViewer extends PreferenceActivity {
         super.onPostCreate(savedInstanceState);
         setupSimplePreferencesScreen();
         registerListener(getApplicationContext());
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        startService(new Intent(this, TimerService.class));
     }
 
     private void setupSimplePreferencesScreen() {

--- a/app/src/main/res/values/strings_pref_values.xml
+++ b/app/src/main/res/values/strings_pref_values.xml
@@ -111,10 +111,10 @@
     <string name="pref_summary_notify_make">Constriction Notifications (Equipment)</string>
 
     <string name="pref_title_textsize_minor">信息挂件字体大小</string>
-    <string name="pref_default_textsize_minor">48</string>
+    <string name="pref_default_textsize_minor">24</string>
 
     <string name="pref_title_textsize_major">主挂件字体大小</string>
-    <string name="pref_default_textsize_major">48</string>
+    <string name="pref_default_textsize_major">24</string>
 
     <string name="pref_title_black">黑科技开关</string>
     <string name="pref_summary_black">比较新奇的玩意，请谨慎使用</string>

--- a/app/src/main/res/values/strings_pref_values.xml
+++ b/app/src/main/res/values/strings_pref_values.xml
@@ -97,6 +97,7 @@
     </string-array>
 
     <string name="pref_title_on">总开关</string>
+    <string name="pref_auto_on">自动模式</string>
     <string name="pref_title_notify_general">开启推送通知</string>
     <string name="pref_title_notify_travel">远征结束通知</string>
     <string name="pref_title_notify_repair">维修结束通知</string>

--- a/app/src/main/res/xml/pref_part_main_settings.xml
+++ b/app/src/main/res/xml/pref_part_main_settings.xml
@@ -5,6 +5,11 @@
         android:title="@string/pref_title_on"
         android:defaultValue="true" />
 
+    <SwitchPreference
+        android:key="auto_run"
+        android:title="@string/pref_auto_on"
+        android:defaultValue="true" />
+
     <Preference
         android:title="@string/pref_header_account"
         android:summary="@string/pref_summary_account"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed May 25 15:22:41 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
首先是取消了读取系统事件，判断zjsn是否在前台的API需要的特别的权限，这一点在6.0中尤其麻烦。
一开始是增加了要求权限的代码，不过后来发现换个逻辑更好。
改为另一个人造好的轮子。
逻辑上，从“切到后台就可以顶号”变成了“必须进程被杀掉才可以顶号”
至少对我来说，有时候切出去水个论坛然后发现需要重新登录是很麻烦的一件事儿。

另一部分更新是添加了服务的重启机制，被kill之后会自动重启。
虽然不知道以前必须在widget被更新的时候才会启动服务的逻辑是怎样的，不过我在6.0环境下使用的时候服务经常自己死掉，开关总开关也没用。应该是有些API在6.0被禁用了。
