### PR TITLE
通知修改和IOS服务器增加

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: android
-jdk: openjdk7
+jdk: openjdk8
 android:
   components:
-  - build-tools-21.1.2
+  - build-tools-23.0.3
   - android-23
   - extra-android-support
   - extra-google-m2repository

--- a/app/app.iml
+++ b/app/app.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -80,6 +72,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -82,6 +82,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
@@ -98,6 +99,8 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />

--- a/app/app.iml
+++ b/app/app.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -80,9 +72,16 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
@@ -99,8 +98,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "me.crafter.android.zjsnviewer"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 28
-        versionName "2.7.1"
+        versionCode 29
+        versionName "2.7.2"
     }
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 28
-        versionName "2.7.1rc2"
+        versionName "2.7.1"
     }
     lintOptions {
         abortOnError false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
         applicationId "me.crafter.android.zjsnviewer"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 27
+        versionCode 28
         versionName "2.7.1rc2"
     }
     lintOptions {

--- a/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/DockInfo.java
@@ -133,6 +133,7 @@ public class DockInfo {
 
     public static boolean shouldNotify(Context context){
         // First check no disturb
+        Log.d("DockInfo", "check notify");
         if (Storage.isNoDisturbNow(context)) return false;
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
@@ -54,7 +54,13 @@ public class NetworkManager {
             "http://s9.jianniang.com/",
             "http://s10.jianniang.com/",
             "http://s11.jianniang.com/",
-            "http://s12.jianniang.com/"
+            "http://s12.jianniang.com/",
+            "http://s101.jianniang.com/",
+            "http://s102.jianniang.com/",
+            "http://s103.jianniang.com/",
+            "http://s104.jianniang.com/",
+            "http://s105.jianniang.com/",
+            "http://s106.jianniang.com/"
     };
 
     public static String getCurrentUnixTime() {

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
@@ -88,7 +88,7 @@ public class NetworkManager {
             server = url_server_hm[serverId-100];
         }
         else {
-            server = url_server_hm_ios[serverId-200];
+            server = url_server_hm_ios[serverId-201];
         }
 
         // Black: Alt Server

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NetworkManager.java
@@ -27,6 +27,7 @@ public class NetworkManager {
     public static String url_passport_p7 = "http://login.alpha.p7game.com/index/passportLogin/";// +username/password
     //hm change the login in url as http://login.jianniang.com/index/passportLogin/
     public static String url_passport_hm = "http://login.jianniang.com/index/passportLogin/";// +username/password
+    public static String url_passport_hm_ios = "http://loginios.jianniang.com/index/passportLogin/";// +username/password
     public static String url_login = "index/login/";//+uid
     public static String[] url_server_p7 = {
             "http://zj.alpha.p7game.com/",
@@ -54,15 +55,17 @@ public class NetworkManager {
             "http://s9.jianniang.com/",
             "http://s10.jianniang.com/",
             "http://s11.jianniang.com/",
-            "http://s12.jianniang.com/",
-            "http://s101.jianniang.com/",
-            "http://s102.jianniang.com/",
-            "http://s103.jianniang.com/",
-            "http://s104.jianniang.com/",
-            "http://s105.jianniang.com/",
-            "http://s106.jianniang.com/"
+            "http://s12.jianniang.com/"
     };
 
+    public static String[] url_server_hm_ios = {
+        "http://s101.jianniang.com/",
+        "http://s102.jianniang.com/",
+        "http://s103.jianniang.com/",
+        "http://s104.jianniang.com/",
+        "http://s105.jianniang.com/",
+        "http://s106.jianniang.com/"
+    };
     public static String getCurrentUnixTime() {
         long unixTime = System.currentTimeMillis() / 10L;
         return String.valueOf(unixTime);
@@ -77,10 +80,15 @@ public class NetworkManager {
         String server = prefs.getString("server", "-1");
         if (server.equals("-1")) return;
         int serverId = Integer.parseInt(server);
+
         if (serverId < 100){
             server = url_server_p7[serverId];
-        } else {
+        }
+        else if (serverId < 200) {
             server = url_server_hm[serverId-100];
+        }
+        else {
+            server = url_server_hm_ios[serverId-200];
         }
 
         // Black: Alt Server
@@ -111,8 +119,10 @@ public class NetworkManager {
             URL url;
             if (serverId < 100){
                 url = new URL(url_passport_p7 +username+"/"+password);
-            } else {
+            }else if (serverId < 200){
                 url = new URL(url_passport_hm +username+"/"+password);
+            }else {
+                url = new URL(url_passport_hm_ios +username+"/"+password);
             }
             if (altserver){
                 url = new URL(prefs.getString("alt_url_login", "") +username+"/"+password);

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NotificationSender.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NotificationSender.java
@@ -22,8 +22,8 @@ public class NotificationSender {
         final Resources res = context.getResources();
 
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean screen_light = prefs.getBoolean("notification_screen_light", true);
-        boolean if_send_vibration = prefs.getBoolean("notification_vibration", true);
+        final boolean screen_light = prefs.getBoolean("notification_screen_light", true);
+        final boolean if_send_vibration = prefs.getBoolean("notification_vibration", true);
 
         final NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
 //                .setDefaults(Notification.DEFAULT_ALL)
@@ -34,15 +34,19 @@ public class NotificationSender {
 //                .setStyle(new Notification.InboxStyle())
 //                TODO 加个是否显示浮动窗口的选项
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setDefaults(NotificationCompat.DEFAULT_ALL)
+                .setDefaults(NotificationCompat.DEFAULT_LIGHTS|NotificationCompat.DEFAULT_SOUND)
                 .setContentIntent(Storage.getStartPendingIntent(context))
                 .setAutoCancel(true);
 
-        if (!if_send_vibration)  builder.setVibrate(new long[0]);
+        if (if_send_vibration) {
+            builder.setDefaults(NotificationCompat.DEFAULT_VIBRATE);
+        } else {
+            builder.setVibrate(new long[]{0L});
+        }
 
         if(screen_light) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                builder.setVisibility(Notification.VISIBILITY_PUBLIC);
+                builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
             } else {
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
             PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.FULL_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "ZJSN");

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NotificationSender.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NotificationSender.java
@@ -3,13 +3,10 @@ package me.crafter.android.zjsnviewer;
 import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
@@ -27,26 +24,33 @@ public class NotificationSender {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean screen_light = prefs.getBoolean("notification_screen_light", true);
 
-        final Notification.Builder builder = new Notification.Builder(context)
-                .setDefaults(Notification.DEFAULT_ALL)
+        final NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+//                .setDefaults(Notification.DEFAULT_ALL)
                 .setSmallIcon(R.drawable.logo)
                 .setContentTitle(title)
                 .setContentText(text)
-                .setStyle(new Notification.BigTextStyle().bigText(text))
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+//                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+//                TODO 加个是否显示浮动窗口的选项
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
+                .setDefaults(Notification.DEFAULT_LIGHTS)
                 .setContentIntent(Storage.getStartPendingIntent(context))
                 .setAutoCancel(true);
 
         if(screen_light) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                builder.setVisibility(Notification.VISIBILITY_PUBLIC);
+            } else {
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
             PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.FULL_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "ZJSN");
             wl.acquire(10000);
+            }
         }
-        notify(context, builder.build());
+        SendNotification(context, builder.build());
     }
 
     @TargetApi(Build.VERSION_CODES.ECLAIR)
-    private static void notify(final Context context, final Notification notification) {
+    private static void SendNotification(final Context context, final Notification notification) {
         final NotificationManager nm = (NotificationManager) context
                 .getSystemService(Context.NOTIFICATION_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ECLAIR) {

--- a/app/src/main/java/me/crafter/android/zjsnviewer/NotificationSender.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/NotificationSender.java
@@ -23,19 +23,22 @@ public class NotificationSender {
 
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean screen_light = prefs.getBoolean("notification_screen_light", true);
+        boolean if_send_vibration = prefs.getBoolean("notification_vibration", true);
 
         final NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
 //                .setDefaults(Notification.DEFAULT_ALL)
                 .setSmallIcon(R.drawable.logo)
                 .setContentTitle(title)
                 .setContentText(text)
-//                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
+//                .setStyle(new Notification.InboxStyle())
 //                TODO 加个是否显示浮动窗口的选项
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
-                .setDefaults(Notification.DEFAULT_LIGHTS)
+                .setDefaults(NotificationCompat.DEFAULT_ALL)
                 .setContentIntent(Storage.getStartPendingIntent(context))
                 .setAutoCancel(true);
+
+        if (!if_send_vibration)  builder.setVibrate(new long[0]);
 
         if(screen_light) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.PowerManager;
@@ -33,11 +34,11 @@ public class TimerService extends Service {
     // timer handling
     private Timer mTimer = null;
 
-    @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        // If we get killed, after returning from here, restart
-        return START_STICKY;
-    }
+//    @Override
+//    public int onStartCommand(Intent intent, int flags, int startId) {
+//        // If we get killed, after returning from here, restart
+//        return START_STICKY;
+//    }
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -106,7 +107,13 @@ public class TimerService extends Service {
             //check if screen is on
             //if screen not on, widget should not update
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-            if (!pm.isScreenOn()){
+            boolean screenon = true;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH){
+                screenon = pm.isInteractive();
+            } else {
+                screenon = pm.isScreenOn();
+            }
+            if (!screenon){
                 //Log.i("TimerService", "run() - Screen is off, ignores update.");
             } else {
                 int currentUnix = DockInfo.currentUnix();

--- a/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/Widget_Main.java
@@ -58,6 +58,10 @@ public class Widget_Main extends AppWidgetProvider {
             DockInfo.updateInterval = 1;
             DockInfo.requestUpdate(context);
             Widget_Main.updateWidget(context);
+            Widget_Travel.updateWidget(context);
+            Widget_Repair.updateWidget(context);
+            Widget_Build.updateWidget(context);
+            Widget_Make.updateWidget(context);
             return null;
         }
     }

--- a/app/src/main/res/values/strings_pref_values.xml
+++ b/app/src/main/res/values/strings_pref_values.xml
@@ -133,7 +133,7 @@
     <string name="pref_title_black">黑科技开关</string>
     <string name="pref_summary_black">比较新奇的玩意，请谨慎使用</string>
     <string name="pref_title_root">真·黑科技 (未完成)</string>
-    <string name="pref_summary_root">无视平战舰少女R与服务器，甚至不需要设置用户名密码，需要root权限支持</string>
+    <string name="pref_summary_root">无视平台与服务器，甚至不需要设置用户名密码，需要root权限支持</string>
     <string name="pref_title_alt_server">手动输入服务器</string>
     <string name="pref_summary_alt_server">高级选项，强制使用输入的服务器地址，使用方法请参见网站。</string>
 

--- a/app/src/main/res/values/strings_pref_values.xml
+++ b/app/src/main/res/values/strings_pref_values.xml
@@ -26,31 +26,54 @@
     </string-array>
 
     <string-array name="pref_choice_server_name">
-        <item>[国] ZERO</item>
-        <item>[国] 胡德</item>
-        <item>[国] 萨拉托加</item>
-        <item>[国] 俾斯麦</item>
-        <item>[国] 声望</item>
-        <item>[国] 纳尔逊</item>
-        <item>[国] 空想</item>
-        <item>[国] 海伦娜</item>
-        <item>[国] 突击者</item>
-        <item>[国] 黎塞留</item>
-        <item>[国] 贝尔法斯特</item>
-        <item>[国] 追赶者</item>
-        <item>[台] 胡德</item>
-        <item>[台] 萨拉托加</item>
-        <item>[台] 俾斯麦</item>
-        <item>[台] 声望</item>
-        <item>[台] 纳尔逊</item>
-        <item>[台] 空想</item>
-        <item>[台] 海伦娜</item>
-        <item>[台] 突击者</item>
-        <item>[台] 黎赛留</item>
-        <item>[台] 贝尔法斯特</item>
-        <item>[台] 埃塞克斯</item>
+        <item>[战舰少女R] 胡德</item>
+        <item>[战舰少女R] 萨拉托加</item>
+        <item>[战舰少女R] 俾斯麦</item>
+        <item>[战舰少女R] 声望</item>
+        <item>[战舰少女R] 纳尔逊</item>
+        <item>[战舰少女R] 空想</item>
+        <item>[战舰少女R] 海伦娜</item>
+        <item>[战舰少女R] 突击者</item>
+        <item>[战舰少女R] 黎赛留</item>
+        <item>[战舰少女R] 贝尔法斯特</item>
+        <item>[战舰少女R] 埃塞克斯</item>
+        <item>[战舰少女R] 列克星敦</item>
+        <item>[战舰少女R] 欧根亲王</item>
+        <item>[战舰少女R] 提尔比茨</item>
+        <item>[战舰少女R] 大青花鱼</item>
+        <item>[战舰少女R] 阿拉斯加</item>
+        <item>[战舰少女R] 皇家方舟</item>
+        <item>[战舰少女] ZERO</item>
+        <item>[战舰少女] 胡德</item>
+        <item>[战舰少女] 萨拉托加</item>
+        <item>[战舰少女] 俾斯麦</item>
+        <item>[战舰少女] 声望</item>
+        <item>[战舰少女] 纳尔逊</item>
+        <item>[战舰少女] 空想</item>
+        <item>[战舰少女] 海伦娜</item>
+        <item>[战舰少女] 突击者</item>
+        <item>[战舰少女] 黎塞留</item>
+        <item>[战舰少女] 贝尔法斯特</item>
+        <item>[战舰少女] 追赶者</item>
     </string-array>
     <string-array name="pref_choice_server_values">
+        <item>101</item>
+        <item>102</item>
+        <item>103</item>
+        <item>104</item>
+        <item>105</item>
+        <item>106</item>
+        <item>107</item>
+        <item>108</item>
+        <item>109</item>
+        <item>110</item>
+        <item>111</item>
+        <item>112</item>
+        <item>113</item>
+        <item>114</item>
+        <item>115</item>
+        <item>116</item>
+        <item>117</item>
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -63,17 +86,6 @@
         <item>9</item>
         <item>10</item>
         <item>11</item>
-        <item>101</item>
-        <item>102</item>
-        <item>103</item>
-        <item>104</item>
-        <item>105</item>
-        <item>106</item>
-        <item>107</item>
-        <item>108</item>
-        <item>109</item>
-        <item>110</item>
-        <item>111</item>
     </string-array>
 
     <string name="pref_title_refresh">挂件刷新时间</string>
@@ -121,7 +133,7 @@
     <string name="pref_title_black">黑科技开关</string>
     <string name="pref_summary_black">比较新奇的玩意，请谨慎使用</string>
     <string name="pref_title_root">真·黑科技 (未完成)</string>
-    <string name="pref_summary_root">无视平台与服务器，甚至不需要设置用户名密码，需要root权限支持</string>
+    <string name="pref_summary_root">无视平战舰少女R与服务器，甚至不需要设置用户名密码，需要root权限支持</string>
     <string name="pref_title_alt_server">手动输入服务器</string>
     <string name="pref_summary_alt_server">高级选项，强制使用输入的服务器地址，使用方法请参见网站。</string>
 

--- a/app/src/main/res/values/strings_pref_values.xml
+++ b/app/src/main/res/values/strings_pref_values.xml
@@ -68,12 +68,12 @@
         <item>109</item>
         <item>110</item>
         <item>111</item>
-        <item>112</item>
-        <item>113</item>
-        <item>114</item>
-        <item>115</item>
-        <item>116</item>
-        <item>117</item>
+        <item>201</item>
+        <item>202</item>
+        <item>203</item>
+        <item>204</item>
+        <item>205</item>
+        <item>206</item>
         <item>0</item>
         <item>1</item>
         <item>2</item>

--- a/app/src/main/res/values/strings_pref_values.xml
+++ b/app/src/main/res/values/strings_pref_values.xml
@@ -104,6 +104,7 @@
     <string name="pref_title_notify_build">建造结束通知</string>
     <string name="pref_title_notify_make">开发结束通知</string>
     <string name="pref_title_notify_screen_light">通知时点亮屏幕</string>
+    <string name="pref_title_notify_vibration">通知时震动</string>
 
     <string name="pref_summary_notify_general">Turn On Notifications</string>
     <string name="pref_summary_notify_travel">Expedition Notifications</string>

--- a/app/src/main/res/xml/pref_part_general.xml
+++ b/app/src/main/res/xml/pref_part_general.xml
@@ -22,7 +22,7 @@
     <ListPreference
         android:key="server"
         android:title="@string/pref_title_server_name"
-        android:defaultValue="0"
+        android:defaultValue="101"
         android:entries="@array/pref_choice_server_name"
         android:entryValues="@array/pref_choice_server_values"
         android:negativeButtonText="@null"

--- a/app/src/main/res/xml/pref_part_notification.xml
+++ b/app/src/main/res/xml/pref_part_notification.xml
@@ -38,6 +38,11 @@
         android:title="@string/pref_title_notify_screen_light"
         android:defaultValue="true" />
 
+    <CheckBoxPreference
+        android:key="notification_vibration"
+        android:title="@string/pref_title_notify_vibration"
+        android:defaultValue="true" />
+
     <SwitchPreference
         android:dependency="notification_general"
         android:key="notification_do_not_disturb_on"


### PR DESCRIPTION
通知现在可以是heads-up（横幅）模式的了，不过需要用户手动给横幅通知权限  
优化了锁屏界面通知的处理方式，对Lollipop以上版本可以在锁屏界面显示通知详情并且自动点亮屏幕，以下版本的处理不变
增加了通知是否发送震动的选项
增加了战舰少女R的IOS服务器选项
将过时的[国]，[台]服务器区分更换为[战舰少女]和[战舰少女R]
一些其他的优化
